### PR TITLE
Fix test fails on older Perls

### DIFF
--- a/t/06-missing-hidden-modules.t
+++ b/t/06-missing-hidden-modules.t
@@ -28,5 +28,5 @@ Test::Without::Module->import('IO::Socket');
 
 ($failed,$error,$inc) = tryload( 'IO::Socket' );
 is $failed, 1, "a non-existing module fails to load";
-like $error, qr!Can't locate IO/Socket.pm in \@INC( \(you may need to install the IO::Socket module\))? \(\@INC contains: ...\) line (\d+).!, 'error message for hidden module shows @INC';
+like $error, qr!Can't locate IO/Socket.pm in \@INC( \(you may need to install the IO::Socket module\))? \(\@INC contains: ...\) line (\d+)!, 'error message for hidden module shows @INC';
 #diag $error;


### PR DESCRIPTION
Prior to 5.16, I'm getting test failures like this:
```
#   Failed test 'error message for hidden module shows @INC'
#   at t/06-missing-hidden-modules.t line 31.
#                   'Can't locate IO/Socket.pm in @INC (you may need to install the IO::Socket module) (@INC contains: ...) line 1'
#     doesn't match '(?^:Can't locate IO/Socket.pm in \@INC( \(you may need to install the IO::Socket module\))? \(\@INC contains: ... \) line (\d+).)'
# Looks like you failed 1 test of 5.
t/06-missing-hidden-modules.t .....
Dubious, test returned 1 (wstat 256, 0x100)
Failed 1/5 subtests
```